### PR TITLE
Added option to disable padding animation on item change

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Widget build(BuildContext context) {
 
 ```
 
-The constructor has 16 attributes related to the Widget:
+The constructor has 17 attributes related to the Widget:
 
 - `items`: A list of tabs to display, ie `Home`, `Profile`,`Cart`, etc
 - `currentIndex`: The tab to display.
@@ -143,6 +143,7 @@ The constructor has 16 attributes related to the Widget:
 - `backgroundColor`:bgd colors for the nav bar.
 - `boxShadow`: floating nav bar shadow ,it takes `List of BoxShadow`
 - `enableFloatingNavBar`: make Floating nav bar enabled.
+- `enablePaddingAnimation`: enable the animation on item during item change.
 
 ## default values
  marginR = const EdgeInsets.symmetric(horizontal: 50, vertical: 20),
@@ -153,6 +154,7 @@ borderRadius = 30,
 
 backgroundColor =  Colors.white,
 enableFloatingNavBar=true,
+enablePaddingAnimation=true
 
 ## Contributors
 @iamvivekkaushik

--- a/lib/src/NavBars.dart
+++ b/lib/src/NavBars.dart
@@ -12,8 +12,7 @@ class DotNavigationBar extends StatelessWidget {
       this.selectedItemColor,
       this.unselectedItemColor,
       this.margin = const EdgeInsets.all(8),
-      this.itemPadding =
-          const EdgeInsets.symmetric(vertical: 10, horizontal: 16),
+      this.itemPadding = const EdgeInsets.symmetric(vertical: 10, horizontal: 16),
       this.duration = const Duration(milliseconds: 500),
       this.curve = Curves.easeOutQuint,
       this.dotIndicatorColor,
@@ -29,7 +28,8 @@ class DotNavigationBar extends StatelessWidget {
           offset: Offset(0, 0), // changes position of shadow
         ),
       ],
-      this.enableFloatingNavBar = true})
+      this.enableFloatingNavBar = true,
+      this.enablePaddingAnimation = true})
       : super(key: key);
 
   /// A list of tabs to display, ie `Home`, `Profile`,`Cart`, etc
@@ -77,6 +77,7 @@ class DotNavigationBar extends StatelessWidget {
   /// List of box shadow
   final List<BoxShadow> boxShadow;
   final bool enableFloatingNavBar;
+  final bool enablePaddingAnimation;
 
   @override
   Widget build(BuildContext context) {
@@ -111,7 +112,8 @@ class DotNavigationBar extends StatelessWidget {
                           unselectedItemColor: unselectedItemColor,
                           onTap: onTap!,
                           itemPadding: itemPadding,
-                          dotIndicatorColor: dotIndicatorColor),
+                          dotIndicatorColor: dotIndicatorColor,
+                          enablePaddingAnimation: enablePaddingAnimation),
                     ),
                   ),
                 ),
@@ -133,7 +135,8 @@ class DotNavigationBar extends StatelessWidget {
                   unselectedItemColor: unselectedItemColor,
                   onTap: onTap!,
                   itemPadding: itemPadding,
-                  dotIndicatorColor: dotIndicatorColor),
+                  dotIndicatorColor: dotIndicatorColor,
+                  enablePaddingAnimation: enablePaddingAnimation),
             ),
           );
   }

--- a/lib/src/body.dart
+++ b/lib/src/body.dart
@@ -16,6 +16,7 @@ class Body extends StatelessWidget {
     required this.onTap,
     required this.itemPadding,
     required this.dotIndicatorColor,
+    required this.enablePaddingAnimation,
   }) : super(key: key);
 
   final List<DotNavigationBarItem> items;
@@ -28,6 +29,7 @@ class Body extends StatelessWidget {
   final Function(int p1) onTap;
   final EdgeInsets itemPadding;
   final Color? dotIndicatorColor;
+  final bool enablePaddingAnimation;
 
   @override
   Widget build(BuildContext context) {
@@ -59,8 +61,9 @@ class Body extends StatelessWidget {
                   hoverColor: _selectedColor.withOpacity(0.1),
                   child: Stack(children: <Widget>[
                     Padding(
-                      padding: itemPadding -
-                          EdgeInsets.only(right: itemPadding.right * t),
+                      padding: itemPadding - (enablePaddingAnimation 
+                          ? EdgeInsets.only(right: itemPadding.right * t) 
+                          : EdgeInsets.zero),
                       child: Row(
                         children: [
                           IconTheme(


### PR DESCRIPTION
Noticed that having dynamic padding for the item is not looking nice when you want to have an item in the center. 

**Before**
| Not Selected| Selected |
| ----------- | ----------- |
| ![Screenshot_20220301-233127](https://user-images.githubusercontent.com/49204989/156297556-7e268e90-609c-49b5-aaf0-8fcfaabc66aa.png) | ![Screenshot_20220301-234214](https://user-images.githubusercontent.com/49204989/156297572-19d0bd8c-0798-44a3-90e5-4bfde7fc1c9c.png) |

**This PR**
| Not Selected| Selected |
| ----------- | ----------- |
| ![Screenshot_20220301-232207](https://user-images.githubusercontent.com/49204989/156297466-935b9202-f747-4ec0-b1d1-4ae22e08131d.png) | ![Screenshot_20220301-232214](https://user-images.githubusercontent.com/49204989/156297521-46079a63-fb57-4662-b39c-0408fd254ecf.png) |