### PR TITLE
Modified the items  `InkWell`' boundries

### DIFF
--- a/lib/src/body.dart
+++ b/lib/src/body.dart
@@ -53,6 +53,8 @@ class Body extends StatelessWidget {
 
               return Material(
                 color: Color.lerp(Colors.transparent, Colors.transparent, t),
+                borderRadius: BorderRadius.circular(8),
+                clipBehavior: Clip.antiAlias,
                 child: InkWell(
                   onTap: () => onTap.call(items.indexOf(item)),
                   focusColor: _selectedColor.withOpacity(0.1),


### PR DESCRIPTION
Adding `borderRadius` and `clipBehavior` to items `Material` widget makes it looks nice when pressing/hovering.

Do you think this should be optional? Even more, customizable?

| Normal | When pressed/hovered |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/49204989/158097448-1e4b6b6a-681c-4d46-bda1-ec6fcc06bbaf.png)   | ![image](https://user-images.githubusercontent.com/49204989/158097471-005e83de-7c49-43e9-b3bd-8b5fd16e1288.png)  |



