### PR TITLE
Fix for RenderFlex Overflow with useMaterial3 and Default Margin/Padding Values

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,63 +27,43 @@ class Home extends StatefulWidget {
   _HomeState createState() => _HomeState();
 }
 
-class _HomeState extends State<Home>  with TickerProviderStateMixin {
+class _HomeState extends State<Home> with TickerProviderStateMixin {
   var _selectedTab = _SelectedTab.home;
 
-  void _handleIndexChanged(int i) {
+  void _handleIndexChanged(int index) {
     setState(() {
-      _selectedTab = _SelectedTab.values[i];
+      _selectedTab = _SelectedTab.values[index];
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    var anim = AnimationController(
-      vsync: this,
-      value: 1,
-      duration: const Duration(milliseconds: 500),
-    );
     return Scaffold(
       extendBody: true,
       body: Container(
         child: Image.asset("lib/img/1.png"),
       ),
-      bottomNavigationBar: Padding(
-        padding: EdgeInsets.only(bottom: 10),
-        child: DotNavigationBar(
-          margin: EdgeInsets.only(left: 10, right: 10),
-          currentIndex: _SelectedTab.values.indexOf(_selectedTab),
-          dotIndicatorColor: Colors.white,
-          unselectedItemColor: Colors.grey[300],
-          splashBorderRadius: 50,
-          // enableFloatingNavBar: false,
-          onTap: _handleIndexChanged,
-          items: [
-            /// Home
-            DotNavigationBarItem(
-              icon: Icon(Icons.home),
-              selectedColor: Color(0xff73544C),
-            ),
-
-            /// Likes
-            DotNavigationBarItem(
-              icon: Icon(Icons.favorite),
-              selectedColor: Color(0xff73544C),
-            ),
-
-            /// Search
-            DotNavigationBarItem(
-              icon: Icon(Icons.search),
-              selectedColor: Color(0xff73544C),
-            ),
-
-            /// Profile
-            DotNavigationBarItem(
-              icon: Icon(Icons.person),
-              selectedColor: Color(0xff73544C),
-            ),
-          ],
-        ),
+      bottomNavigationBar: DotNavigationBar(
+        currentIndex: _SelectedTab.values.indexOf(_selectedTab),
+        dotIndicatorColor: Color(0xff73544C),
+        selectedItemColor: Color(0xff73544C),
+        unselectedItemColor: Colors.grey[300],
+        splashBorderRadius: 50,
+        onTap: _handleIndexChanged,
+        items: [
+          DotNavigationBarItem(
+            icon: Icon(Icons.home),
+          ),
+          DotNavigationBarItem(
+            icon: Icon(Icons.favorite),
+          ),
+          DotNavigationBarItem(
+            icon: Icon(Icons.search),
+          ),
+          DotNavigationBarItem(
+            icon: Icon(Icons.person),
+          ),
+        ],
       ),
     );
   }

--- a/lib/src/NavBars.dart
+++ b/lib/src/NavBars.dart
@@ -12,12 +12,12 @@ class DotNavigationBar extends StatelessWidget {
     this.selectedItemColor,
     this.unselectedItemColor,
     this.margin = const EdgeInsets.all(8),
-    this.itemPadding = const EdgeInsets.symmetric(vertical: 10, horizontal: 16),
+    this.itemPadding = const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
     this.duration = const Duration(milliseconds: 500),
     this.curve = Curves.easeOutQuint,
     this.dotIndicatorColor,
-    this.marginR = const EdgeInsets.symmetric(horizontal: 50, vertical: 20),
-    this.paddingR = const EdgeInsets.only(bottom: 5, top: 10),
+    this.marginR,
+    this.paddingR,
     this.borderRadius = 30,
     this.splashBorderRadius,
     this.backgroundColor = Colors.white,
@@ -98,43 +98,39 @@ class DotNavigationBar extends StatelessWidget {
         ? BottomAppBar(
             color: Colors.transparent,
             elevation: 0,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                Padding(
-                  padding: marginR!,
-                  child: Container(
-                    padding: paddingR,
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(borderRadius!),
-                      color: backgroundColor,
-                      boxShadow: boxShadow,
-                    ),
-                    width: double.infinity,
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 8),
-                      child: Body(
-                          items: items,
-                          currentIndex: currentIndex,
-                          curve: curve,
-                          duration: duration,
-                          selectedItemColor: selectedItemColor,
-                          theme: theme,
-                          unselectedItemColor: unselectedItemColor,
-                          onTap: onTap!,
-                          itemPadding: itemPadding,
-                          dotIndicatorColor: dotIndicatorColor,
-                          enablePaddingAnimation: enablePaddingAnimation,
-                          splashColor: splashColor,
-                          splashBorderRadius: splashBorderRadius),
-                    ),
+            child: Padding(
+              padding: marginR ?? EdgeInsets.zero,
+              child: Container(
+                padding: paddingR ?? EdgeInsets.zero,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(borderRadius!),
+                  color: backgroundColor,
+                  boxShadow: boxShadow,
+                ),
+                width: double.infinity,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: Body(
+                    items: items,
+                    currentIndex: currentIndex,
+                    curve: curve,
+                    duration: duration,
+                    selectedItemColor: selectedItemColor,
+                    theme: theme,
+                    unselectedItemColor: unselectedItemColor,
+                    onTap: onTap!,
+                    itemPadding: itemPadding,
+                    dotIndicatorColor: dotIndicatorColor,
+                    enablePaddingAnimation: enablePaddingAnimation,
+                    splashColor: splashColor,
+                    splashBorderRadius: splashBorderRadius,
                   ),
                 ),
-              ],
+              ),
             ),
           )
         : Container(
-            padding: EdgeInsets.symmetric(vertical: 12),
+            padding: EdgeInsets.symmetric(vertical: 16),
             color: backgroundColor,
             child: Padding(
               padding: margin,


### PR DESCRIPTION
This PR addresses the RenderFlex overflowed by 43 pixels on the bottom. error encountered when useMaterial3: true is set. 

issues:
- [The DotNavigationBar overflowed by 43 pixels on the bottom. ](https://github.com/haptome/dot_navigation_bar/issues/15) 

- [There is bug when using material 3 "Size Error"](https://github.com/haptome/dot_navigation_bar/issues/20)
 
 We resolved this issue by specifying EdgeInsets.zero as the default value for the marginR and paddingR properties, ensuring proper layout without overflow. Additionally, we aligned the spacing with Material Design guidelines by adjusting margins and paddings to be multiples of 8, enhancing design consistency and adherence to standards.
 
 <img src='' width=350>

|before|after|
|---|---|
|![](https://github.com/haptome/dot_navigation_bar/assets/91307335/d16c305e-742e-4750-a32c-8397c048b924)|![](https://github.com/haptome/dot_navigation_bar/assets/91307335/92d5ccb3-bb2d-4622-afd8-40697f0c6070)|